### PR TITLE
Minor bugfixes

### DIFF
--- a/src/api/handler.clj
+++ b/src/api/handler.clj
@@ -9,7 +9,7 @@
             [compojure.coercions :as coerce]))
 
 (defn ^:private parse-int [number-string]
-  (try (Integer/parseInt number-string)
+  (try (Long/parseLong number-string)
        (catch Exception e nil)))
 
 (defn ^:private play-action

--- a/src/persistence/persistence.clj
+++ b/src/persistence/persistence.clj
@@ -3,7 +3,9 @@
 
 ; See `wcar` docstring for opts
 (def server1-conn
-  {:pool {} :spec {:uri "redis://redis"}})
+  {:pool {} :spec {:uri (or
+                          (System/getenv "CARD_GAME_DB")
+                          "redis://localhost")}})
 
 (defmacro wcar*
   [& body] 


### PR DESCRIPTION
**Description**

Just two minor bugfixes:
1. Redis defaults to localhost
2. Numbers are parsed as Long instead of Integer now (Long is the default in Clojure for a literal number like `13`)

**Issues Resolved**

It was faster to solve the issues than make actual issues....

**Details**

The Redis default is mostly for development comfort, but it was pretty annoying.

On the other hand, we were creating games with a key of `{:game-id id}` where id was derived from `next-id` which is initially a literal `0` and therefore initially was of type `java.lang.Long` and **not** `java.lang.Integer`.

Since Clojure defaults to Long, I've switched the parsing to be a conversion into Long, instead of changing the initialization, that way we generally have Long everywhere.

**Checklist for contribution requirements**

- [ ] The tests pass
- [ ] The code has tests
- [ ] The tests are well-designed
- [ ] The code is readable
- [ ] The code is well-organized
- [ ] Any rule changed or included is also on the Manual