### PR TITLE
:game-status

### DIFF
--- a/src/api/base.clj
+++ b/src/api/base.clj
@@ -18,7 +18,7 @@
     (if (and (= game-id (:game-id game-state))
           (or (= player-id (first (:player-ids game-state)))
             (= player-id (second (:player-ids game-state)))))
-      (if (= (:status (get-game game-id player-id)) messages/play)
+      (if (= (:game-status (get-game game-id player-id)) messages/play)
           (let [new-game-state (play-card/play-card game-state player-id card-id row-id (first target))]
             (if (contains? new-game-state :error)
               new-game-state
@@ -33,7 +33,7 @@
   [ini-config]
   (let [game-id (persistence/next-id)]
     (persistence/save-game
-      {:status messages/no-opp
+      {:game-status messages/no-opp
        :game-id game-id
        :player-ids [(generators/player-uuid {})]})))
 

--- a/src/api/player_view.clj
+++ b/src/api/player_view.clj
@@ -11,5 +11,5 @@
    :cards (functions/get-cards game-state player-id)
    :rows (functions/get-rows game-state player-id)
    :scores (functions/get-scores game-state player-id)
-   :status (functions/get-status game-state player-id)
+   :game-status (functions/get-game-status game-state player-id)
    :winner (functions/get-winner game-state player-id)})

--- a/src/api/player_view_functions.clj
+++ b/src/api/player_view_functions.clj
@@ -71,10 +71,10 @@
           :else
           winner)))
 
-(defn get-status
+(defn get-game-status
   "Returns the status of the game from a player's perspective"
   [game-state player-id]
-  (:status game-state
+  (:game-status game-state
            (if (nil? (get-in game-state [:next-play (keyword player-id)]))
              messages/play
              messages/wait)))

--- a/test/api/base_test.clj
+++ b/test/api/base_test.clj
@@ -13,7 +13,7 @@
   (expect false (=
                  (:game-id (base/create-game))
                  (:game-id (base/create-game))))
-  (expect messages/no-opp (:status (base/create-game)))
+  (expect messages/no-opp (:game-status (base/create-game)))
   (expect nil (:player-ids (base/create-game)))
   (expect true (contains? (base/create-game) :player-id)))
 
@@ -65,13 +65,13 @@
             (base/play-card-as-player game-id p2 0 0))
     
     (expect messages/wait
-            (:status (base/play-card-as-player game-id p1 1 0)))
+            (:game-status (base/play-card-as-player game-id p1 1 0)))
 
     (expect {:error messages/out-of-turn}
             (base/play-card-as-player game-id p1 1 0))
 
     (expect messages/play
-            (:status (base/play-card-as-player game-id p2 11 2)))
+            (:game-status (base/play-card-as-player game-id p2 11 2)))
 
     (expect messages/wait
-            (:status (base/play-card-as-player game-id p2 11 1)))))
+            (:game-status (base/play-card-as-player game-id p2 11 1)))))

--- a/test/api/player_view_functions_test.clj
+++ b/test/api/player_view_functions_test.clj
@@ -90,17 +90,17 @@
                            :player-ids ["winner" "someone"]}
                           "someone")))
 
-(defexpect get-status
+(defexpect get-game-status
   
   ; Status are as intended
   (expect
     messages/play
-    (functions/get-status {:next-play {}} "player"))
+    (functions/get-game-status {:next-play {}} "player"))
   
   (expect
     messages/play
-    (functions/get-status {:next-play {:quick {}}} "slow"))
+    (functions/get-game-status {:next-play {:quick {}}} "slow"))
   
   (expect
     messages/wait
-    (functions/get-status {:next-play {:waiter {}}} "waiter")))
+    (functions/get-game-status {:next-play {:waiter {}}} "waiter")))


### PR DESCRIPTION
**Description**

Changing `:status` to  `:game-status` on the game-state.

**Issues Resolved**

While #4 won't be solved yet, it's a first step for that.

**Details**

We change it to avoid confusion, since the HTTP response will have a `:status` following HTTP protocol.
