### PR TITLE
Waiting opp

### DIFF
--- a/src/api/base.clj
+++ b/src/api/base.clj
@@ -46,7 +46,7 @@
   []
   (let [game-id (persistence/next-id)]
     (persistence/save-game
-      {:lobby-status messages/no-opp
+      {:game-status messages/no-opp
        :game-id game-id
        :player-ids [(generators/player-uuid {})]})))
 

--- a/src/api/player_view_functions.clj
+++ b/src/api/player_view_functions.clj
@@ -81,6 +81,10 @@
   "Returns the status of the game from a player's perspective"
   [game-state player-id]
   (:game-status game-state
-           (if (nil? (get-in game-state [:next-play (keyword player-id)]))
+           (cond
+             (= 1 (count (:player-ids game-state)))
+             messages/no-opp
+             (nil? (get-in game-state [:next-play (keyword player-id)]))
              messages/play
+             :else
              messages/wait)))

--- a/test/api/base_test.clj
+++ b/test/api/base_test.clj
@@ -10,7 +10,7 @@
   (expect false (=
                  (:game-id (base/create-game))
                  (:game-id (base/create-game))))
-  (expect messages/no-opp (:lobby-status (base/create-game)))
+  (expect messages/no-opp (:game-status (base/create-game)))
   (expect nil (:player-ids (base/create-game)))
   (expect true (contains? (base/create-game) :player-id)))
 

--- a/test/api/handler_test.clj
+++ b/test/api/handler_test.clj
@@ -35,18 +35,24 @@
             (keys (:body game)))))
 
 (defexpect handler-get-games-request
-  (let [game-id (:game-id (:body (new-game)))
-        player2-id (:player-id (:body (join-game game-id))) 
-        game (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" player2-id])))]
-    (expect cors-headers (:headers game))
-    (expect 200 (:status game))
-    (expect game-id (:game-id (:body game)))
-    (expect player2-id (:player-id (:body game)))
-    (expect [0 0] (:scores (:body game)))
-    (expect messages/play (:game-status (:body game)))
-    (expect nil (:winner (:body game)))
-    (expect '(:game-id :player-id :cards :rows :scores :game-status :winner)
-            (keys (:body game)))))
+  (let [lobby (new-game)
+        game-id (:game-id (:body lobby))
+        game0 (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" (:player-id (:body lobby))])))]
+    (expect cors-headers (:headers game0))
+    (expect 200 (:status game0))
+    (expect game-id (:game-id (:body game0)))
+    (expect messages/no-opp (:game-status (:body game0)))
+    (let [player2-id (:player-id (:body (join-game game-id)))
+          game (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" player2-id])))]
+      (expect cors-headers (:headers game))
+      (expect 200 (:status game))
+      (expect game-id (:game-id (:body game)))
+      (expect player2-id (:player-id (:body game)))
+      (expect [0 0] (:scores (:body game)))
+      (expect messages/play (:game-status (:body game)))
+      (expect nil (:winner (:body game)))
+      (expect '(:game-id :player-id :cards :rows :scores :game-status :winner)
+              (keys (:body game))))))
 
 (defexpect handler-play-request
   (let [lobby (new-game)

--- a/test/api/handler_test.clj
+++ b/test/api/handler_test.clj
@@ -14,45 +14,37 @@
 (defn new-game [] (handler/handler (mock/request :post "/lobby")))
 (defn join-game [game-id] (handler/handler (mock/request :post (string/join ["/games/" game-id]))))
 
+(defn check-response
+  [response message expected-keys]
+  (expect cors-headers (:headers response))
+  (expect 200 (:status response))
+  (expect message (:game-status (:body response)))
+  (expect expected-keys (keys (:body response))))
+
 (defexpect handler-lobby-request
-  (let [game (new-game)]
-    (expect cors-headers (:headers game))
-    (expect 200 (:status game))
-    (expect messages/no-opp (:lobby-status (:body game)))
-    (expect true (number? (:game-id (:body game))))
-    (expect true (contains? (:body game) :player-id))))
+  (check-response (new-game) messages/no-opp '(:game-status :game-id :player-id)))
 
 (defexpect handler-join-games-request
   (let [game-id (:game-id (:body (new-game)))
         game (join-game game-id)]
-    (expect cors-headers (:headers game))
-    (expect 200 (:status game))
+    (check-response game messages/play '(:game-id :player-id :cards :rows :scores :game-status :winner))
     (expect game-id (:game-id (:body game)))
     (expect [0 0] (:scores (:body game)))
-    (expect messages/play (:game-status (:body game)))
-    (expect nil (:winner (:body game)))
-    (expect '(:game-id :player-id :cards :rows :scores :game-status :winner)
-            (keys (:body game)))))
+    (expect nil (:winner (:body game)))))
 
 (defexpect handler-get-games-request
   (let [lobby (new-game)
         game-id (:game-id (:body lobby))
         game0 (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" (:player-id (:body lobby))])))]
-    (expect cors-headers (:headers game0))
-    (expect 200 (:status game0))
+    (check-response game0 messages/no-opp '(:game-id :player-id :cards :rows :scores :game-status :winner))
     (expect game-id (:game-id (:body game0)))
-    (expect messages/no-opp (:game-status (:body game0)))
     (let [player2-id (:player-id (:body (join-game game-id)))
           game (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" player2-id])))]
-      (expect cors-headers (:headers game))
-      (expect 200 (:status game))
+      (check-response game messages/play '(:game-id :player-id :cards :rows :scores :game-status :winner))
       (expect game-id (:game-id (:body game)))
       (expect player2-id (:player-id (:body game)))
       (expect [0 0] (:scores (:body game)))
-      (expect messages/play (:game-status (:body game)))
-      (expect nil (:winner (:body game)))
-      (expect '(:game-id :player-id :cards :rows :scores :game-status :winner)
-              (keys (:body game))))))
+      (expect nil (:winner (:body game))))))
 
 (defexpect handler-play-request
   (let [lobby (new-game)
@@ -61,13 +53,9 @@
     (join-game game-id)
     (let [game (handler/handler (-> (mock/request :post (string/join ["/games/" game-id "/player/" player-id]))
                                     (mock/json-body {:index 0 :row 0})))]
-      (expect cors-headers (:headers game))
-      (expect 200 (:status game))
+      (check-response game messages/wait '(:game-id :player-id :cards :rows :scores :game-status :winner))
       (expect game-id (:game-id (:body game)))
-      (expect player-id (:player-id (:body game)))
-      (expect messages/wait (:game-status (:body game)))
-      (expect '(:game-id :player-id :cards :rows :scores :game-status :winner)
-              (keys (:body game))))))
+      (expect player-id (:player-id (:body game))))))
 
 (defexpect handler-not-found
   (let [not-found (handler/handler (mock/request :get "/not-a-route"))]

--- a/test/api/handler_test.clj
+++ b/test/api/handler_test.clj
@@ -14,7 +14,7 @@
 (defn new-game [] (handler/handler (mock/request :post "/lobby")))
 (defn join-game [game-id] (handler/handler (mock/request :post (string/join ["/games/" game-id]))))
 
-(defn check-response
+(defn expect-response
   [response message expected-keys]
   (expect cors-headers (:headers response))
   (expect 200 (:status response))
@@ -22,12 +22,12 @@
   (expect expected-keys (keys (:body response))))
 
 (defexpect handler-lobby-request
-  (check-response (new-game) messages/no-opp '(:game-status :game-id :player-id)))
+  (expect-response (new-game) messages/no-opp '(:game-status :game-id :player-id)))
 
 (defexpect handler-join-games-request
   (let [game-id (:game-id (:body (new-game)))
         game (join-game game-id)]
-    (check-response game messages/play '(:game-id :player-id :cards :rows :scores :game-status :winner))
+    (expect-response game messages/play '(:game-id :player-id :cards :rows :scores :game-status :winner))
     (expect game-id (:game-id (:body game)))
     (expect [0 0] (:scores (:body game)))
     (expect nil (:winner (:body game)))))
@@ -36,11 +36,11 @@
   (let [lobby (new-game)
         game-id (:game-id (:body lobby))
         game0 (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" (:player-id (:body lobby))])))]
-    (check-response game0 messages/no-opp '(:game-id :player-id :cards :rows :scores :game-status :winner))
+    (expect-response game0 messages/no-opp '(:game-id :player-id :cards :rows :scores :game-status :winner))
     (expect game-id (:game-id (:body game0)))
     (let [player2-id (:player-id (:body (join-game game-id)))
           game (handler/handler (mock/request :get (string/join ["/games/" game-id "/player/" player2-id])))]
-      (check-response game messages/play '(:game-id :player-id :cards :rows :scores :game-status :winner))
+      (expect-response game messages/play '(:game-id :player-id :cards :rows :scores :game-status :winner))
       (expect game-id (:game-id (:body game)))
       (expect player2-id (:player-id (:body game)))
       (expect [0 0] (:scores (:body game)))
@@ -53,7 +53,7 @@
     (join-game game-id)
     (let [game (handler/handler (-> (mock/request :post (string/join ["/games/" game-id "/player/" player-id]))
                                     (mock/json-body {:index 0 :row 0})))]
-      (check-response game messages/wait '(:game-id :player-id :cards :rows :scores :game-status :winner))
+      (expect-response game messages/wait '(:game-id :player-id :cards :rows :scores :game-status :winner))
       (expect game-id (:game-id (:body game)))
       (expect player-id (:player-id (:body game))))))
 

--- a/test/api/player_view_functions_test.clj
+++ b/test/api/player_view_functions_test.clj
@@ -94,12 +94,16 @@
   ; Status are as intended
   (expect
     messages/play
-    (functions/get-game-status {:next-play {}} "player"))
+    (functions/get-game-status {:player-ids ["p1" "player"] :next-play {}} "player"))
   
   (expect
     messages/play
-    (functions/get-game-status {:next-play {:quick {}}} "slow"))
+    (functions/get-game-status {:player-ids ["jugador1" "slow"] :next-play {:quick {}}} "slow"))
   
   (expect
     messages/wait
-    (functions/get-game-status {:next-play {:waiter {}}} "waiter")))
+    (functions/get-game-status {:player-ids ["waiter" "12345"] :next-play {:waiter {}}} "waiter"))
+  
+  (expect
+    messages/no-opp
+    (functions/get-game-status {:player-ids ["lonelyplayer"] :next-play {}} "lonelyplayer")))


### PR DESCRIPTION
**Description**

Gives "Waiting for opponent" status even when using GET game.
Also a couple of things were changed/solved.

**Issues Resolved**

Resvoles #27 

**Details**

`:lobby-status` was changed to `:game-status` so it keeps some consisntency. It was only used when creating the game, but you can already use "get game", so it has no sense pretending there doesn't exist a game.

Also some tests for http response use the same function now, so it's shorter and (I think) more readable.

**Checklist for contribution requirements**

- [x] The tests pass
- [x] The code has tests
- [x] The tests are well-designed
- [x] The code is readable
- [x] The code is well-organized
- [x] Any rule changed or included is also on the Manual
