### PR TITLE
Multi abilities

### DIFF
--- a/src/configs/cards.clj
+++ b/src/configs/cards.clj
@@ -4,9 +4,9 @@
   "All possible cards"
   {:8 {:power 8}
    :7 {:power 7}
-   :6-overpower {:power 6 :abilities [:row-affinity "overpower" 1]}
-   :5-overpower {:power 5 :abilities [:row-affinity "overpower" 3]}
-   :6-strengthen {:power 6 :abilities [:strengthen 1]}
-   :6-weaken {:power 6 :abilities [:weaken 1]}
-   :4-strengthen {:power 4 :abilities [:strengthen 2]}
-   :4-weaken {:power 4 :abilities [:weaken 2]}})
+   :6-overpower {:power 6 :abilities [[:row-affinity "overpower" 1]]}
+   :5-overpower {:power 5 :abilities [[:row-affinity "overpower" 3]]}
+   :6-strengthen {:power 6 :abilities [[:strengthen 1]]}
+   :6-weaken {:power 6 :abilities [[:weaken 1]]}
+   :4-strengthen {:power 4 :abilities [[:strengthen 2]]}
+   :4-weaken {:power 4 :abilities [[:weaken 2]]}})

--- a/src/rules/abilities.clj
+++ b/src/rules/abilities.clj
@@ -39,13 +39,13 @@
 (defn generate-ability-fn
   "Creates an ability function from its description"
   [ability-description]
-  (let [ability-generator ((first ability-description) ability-list)
-        args (vec (rest ability-description))]
+  (let [ability-generator ((first (first ability-description)) ability-list)
+        args (vec (rest (first ability-description)))]
     (apply ability-generator args)))
 
 (defn required-targets
   "Counts the required targets"
   [ability-description]
-  (if (contains? (set '(:strengthen :weaken)) (first ability-description))
+  (if (contains? (set '(:strengthen :weaken)) (first (first ability-description)))
     1
     0))

--- a/src/rules/abilities.clj
+++ b/src/rules/abilities.clj
@@ -1,5 +1,16 @@
 (ns rules.abilities)
 
+(defn ^:private update-target
+  [gsp]
+  (if (contains? (:play gsp) :targets)
+    (assoc-in
+      (assoc-in gsp
+                [:play :target]
+                (last (:targets (:play gsp) )))
+      [:play :targets]
+      (butlast (:targets (:play gsp))))
+    gsp))
+
 (defn ^:private row-affinity
   [row-type increase]
   (fn
@@ -21,10 +32,11 @@
 ;   "Alters a cards' power, by adding the a defined value to it.
 ;   This power may be negative, resulting in a decrease"
     [gsp]
-    (update-in
-      gsp
-      [:game-state :cards (:target (:play gsp)) :power]
-      #(+ % increase))))
+    (let [gsp (update-target gsp)]
+      (update-in
+        gsp
+        [:game-state :cards (:target (:play gsp)) :power]
+       #(+ % increase)))))
 
 (defn ^:private weaken
   "Same as strengthen but negative"

--- a/src/rules/abilities.clj
+++ b/src/rules/abilities.clj
@@ -36,6 +36,9 @@
    :strengthen strengthen
    :weaken weaken})
 
+(def ^:private targeted-abilities
+  '(:strengthen :weaken))
+
 (defn ^:private generate-ability-fn
   "Creates an ability function from its description"
   [ability-description]
@@ -55,7 +58,13 @@
 
 (defn required-targets
   "Counts the required targets"
-  [ability-description]
-  (if (contains? (set '(:strengthen :weaken)) (first (first ability-description)))
-    1
-    0))
+  [abilities-vector]
+  (loop [abilities abilities-vector
+         needed-targets 0]
+    (if (empty? abilities)
+      needed-targets
+      (recur
+        (rest abilities)
+        (if (contains? (set targeted-abilities) (first (first abilities)))
+          (inc needed-targets)
+          needed-targets)))))

--- a/src/rules/abilities.clj
+++ b/src/rules/abilities.clj
@@ -1,16 +1,5 @@
 (ns rules.abilities)
 
-(defn ^:private update-target
-  [gsp]
-  (if (contains? (:play gsp) :targets)
-    (assoc-in
-      (assoc-in gsp
-                [:play :target]
-                (last (:targets (:play gsp) )))
-      [:play :targets]
-      (butlast (:targets (:play gsp))))
-    gsp))
-
 (defn ^:private row-affinity
   [row-type increase]
   (fn
@@ -32,11 +21,13 @@
 ;   "Alters a cards' power, by adding the a defined value to it.
 ;   This power may be negative, resulting in a decrease"
     [gsp]
-    (let [gsp (update-target gsp)]
+    (update-in
       (update-in
         gsp
-        [:game-state :cards (:target (:play gsp)) :power]
-       #(+ % increase)))))
+        [:game-state :cards (last (:targets (:play gsp))) :power]
+       #(+ % increase))
+      [:play :targets]
+      butlast)))
 
 (defn ^:private weaken
   "Same as strengthen but negative"

--- a/src/rules/play_card.clj
+++ b/src/rules/play_card.clj
@@ -43,7 +43,7 @@
 
 (defn play-card
   "Takes a playing of a card from hand onto a game row and makes it wait until both players had played"
-  [game-state player-id card-id row-id & target]
+  [game-state player-id card-id row-id & targets]
   ; Uses stored :next-play to know who is supposed to play
   (cond 
     (some? (get-in game-state [:next-play (keyword player-id)]))
@@ -59,15 +59,15 @@
     {:error messages/row-limit}
 
     (and (requires-target? game-state card-id)
-         (nil? (first target)))
+         (nil? (first targets)))
     {:error messages/need-target}
 
     (and (requires-target? game-state card-id)
-         (not (identical? (get-in game-state [:cards (first target) :location 0]) :row)))
+         (not (identical? (get-in game-state [:cards (first targets) :location 0]) :row)))
     {:error messages/invalid-target}
 
     :else
-    (let [game-state (assoc-in game-state [:next-play (keyword player-id)] {:card-id card-id :row-id row-id :target (first target)})]
+    (let [game-state (assoc-in game-state [:next-play (keyword player-id)] {:card-id card-id :row-id row-id :targets (first targets)})]
       (if (= 2 (count (:next-play game-state)))
         (apply-all-plays game-state)
         game-state))))

--- a/src/rules/play_card.clj
+++ b/src/rules/play_card.clj
@@ -13,8 +13,7 @@
   [game-state play]
   (let [card (get-in game-state [:cards (:card-id play)])]
     (if (contains? card :abilities)
-      (let [ability (abilities/generate-ability-fn (:abilities card))]
-        (ability game-state play))
+      ((abilities/generate-abilities-fn (:abilities card)) game-state play)
       game-state)))
 
 (defn ^:private apply-all-plays

--- a/src/rules/play_card.clj
+++ b/src/rules/play_card.clj
@@ -36,10 +36,9 @@
       (count-cards/count-cards game-state {:location [:row row-id]
                                            :owner player-id})))
 
-(defn ^:private requires-target?
+(defn ^:private required-targets
   [game-state card-id]
-  (= (abilities/required-targets (:abilities (get-in game-state [:cards card-id])))
-     1))
+  (abilities/required-targets (:abilities (get-in game-state [:cards card-id]))))
 
 (defn play-card
   "Takes a playing of a card from hand onto a game row and makes it wait until both players had played"
@@ -58,11 +57,11 @@
     (crowded-row? game-state row-id player-id)
     {:error messages/row-limit}
 
-    (and (requires-target? game-state card-id)
-         (nil? (first targets)))
+    (and (nil? (first targets))
+         (not= 0 (required-targets game-state card-id)))
     {:error messages/need-target}
 
-    (and (requires-target? game-state card-id)
+    (and (> (required-targets game-state card-id) 0)
          (not (identical? (get-in game-state [:cards (first targets) :location 0]) :row)))
     {:error messages/invalid-target}
 

--- a/test/api/base_test.clj
+++ b/test/api/base_test.clj
@@ -66,7 +66,7 @@
             (base/play-card-as-player game-id p1 4 0))
 
     (expect {:error messages/invalid-target}
-            (base/play-card-as-player game-id p1 4 0 4))
+            (base/play-card-as-player game-id p1 4 0 [4]))
     
     (expect messages/wait
             (:game-status (base/play-card-as-player game-id p1 1 0)))

--- a/test/api/player_view_functions_test.clj
+++ b/test/api/player_view_functions_test.clj
@@ -19,16 +19,16 @@
 
   ; Correctly returns cards with abilities
   (expect
-    [{:card-name "c1" :power 1 :location [:hand] :owner "me" :abilities [:strengthen 100] :target 1}
-     {:card-name "c2" :power 17 :location [:hand] :owner "me" :abilities [:weaken 1] :target 1}
+    [{:card-name "c1" :power 1 :location [:hand] :owner "me" :abilities [[:strengthen 100]] :target 1}
+     {:card-name "c2" :power 17 :location [:hand] :owner "me" :abilities [[:weaken 1]] :target 1}
      {:location [:hand] :owner "opp"}
      {:card-name "c4" :power -20 :location [:row 0] :owner "me"}
      {:card-name "c5" :power 999 :location [:row 1] :owner "opp"}]
-    (functions/get-cards {:cards [{:card-name "c1" :power 1 :location [:hand] :owner "I" :abilities [:strengthen 100]}
-                                  {:card-name "c2" :power 17 :location [:hand] :owner "I" :abilities [:weaken 1]}
-                                  {:card-name "c3" :power 17 :location [:hand] :owner "U" :abilities [:weaken 1]}
-                                  {:card-name "c4" :power -20 :location [:row 0] :owner "I" :abilities [:strengthen 76]}
-                                  {:card-name "c5" :power 999 :location [:row 1] :owner "U" :abilities [:strengthen 22]}]}
+    (functions/get-cards {:cards [{:card-name "c1" :power 1 :location [:hand] :owner "I" :abilities [[:strengthen 100]]}
+                                  {:card-name "c2" :power 17 :location [:hand] :owner "I" :abilities [[:weaken 1]]}
+                                  {:card-name "c3" :power 17 :location [:hand] :owner "U" :abilities [[:weaken 1]]}
+                                  {:card-name "c4" :power -20 :location [:row 0] :owner "I" :abilities [[:strengthen 76]]}
+                                  {:card-name "c5" :power 999 :location [:row 1] :owner "U" :abilities [[:strengthen 22]]}]}
                         "I")))
 
 (defexpect get-rows

--- a/test/rules/abilities_test.clj
+++ b/test/rules/abilities_test.clj
@@ -18,13 +18,13 @@
   ; Adds power
   (expect
     7
-    (get-in ((abilities/generate-ability-fn [[:strengthen 5]]) {:cards [{:power 2}]} {:target 0})
+    (get-in ((abilities/generate-abilities-fn [[:strengthen 5]]) {:cards [{:power 2}]} {:target 0})
             [:cards 0 :power]))
 
   ; Removes power
   (expect
     -10
-    (get-in ((abilities/generate-ability-fn [[:weaken 13]]) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
+    (get-in ((abilities/generate-abilities-fn [[:weaken 13]]) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 
 (defexpect row-affinity
@@ -32,20 +32,36 @@
   ; Does nothing when shouldn't
   (expect
     42
-    (get-in ((abilities/generate-ability-fn [[:row-affinity "invi" 10]]) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "invi" 10]]) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
             [:cards 0 :power]))
   (expect
     99
-    (get-in ((abilities/generate-ability-fn [[:row-affinity "invi" 10]]) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "invi" 10]]) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
             [:cards 1 :power]))
   
   ; Adds power when should
   (expect
     52
-    (get-in ((abilities/generate-ability-fn [[:row-affinity "invi" 10]]) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "invi" 10]]) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
             [:cards 0 :power]))
 
   (expect
     -2
-    (get-in ((abilities/generate-ability-fn [[:row-affinity "vivi" -3]]) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "vivi" -3]]) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
             [:cards 1 :power])))
+
+(defexpect multi-abilities
+
+  (expect
+    11
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "first-row" 10][:row-affinity "second-row" 100]])
+             {:cards [{:power 1}] :rows [{:type "first-row"} {:type "second-row"}]}
+             {:row-id 0 :card-id 0})
+            [:cards 0 :power]))
+
+  (expect
+    101
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "first-row" 10][:row-affinity "second-row" 100]])
+             {:cards [{:power 1}] :rows [{:type "first-row"} {:type "second-row"}]}
+             {:row-id 1 :card-id 0})
+            [:cards 0 :power])))

--- a/test/rules/abilities_test.clj
+++ b/test/rules/abilities_test.clj
@@ -5,13 +5,16 @@
 (defexpect required-targets
   (expect
     1
-    (abilities/required-targets [[:strengthen 1]]))
+    (abilities/required-targets [[:notyetanability 1 2 3 4 5][:strengthen 1]]))
   (expect
     1
     (abilities/required-targets [[:weaken 1]]))
   (expect
     0
-    (abilities/required-targets [[:row-affinity "" 1]])))
+    (abilities/required-targets [[:row-affinity "" 1]]))
+  (expect
+    3
+    (abilities/required-targets [[:a][:weaken][:strengthen 1000][:kaboom][:strengthen 1]])))
 
 (defexpect strengthen-and-weaken
 

--- a/test/rules/abilities_test.clj
+++ b/test/rules/abilities_test.clj
@@ -5,26 +5,26 @@
 (defexpect required-targets
   (expect
     1
-    (abilities/required-targets [:strengthen 1]))
+    (abilities/required-targets [[:strengthen 1]]))
   (expect
     1
-    (abilities/required-targets [:weaken 1]))
+    (abilities/required-targets [[:weaken 1]]))
   (expect
     0
-    (abilities/required-targets [:row-affinity "" 1])))
+    (abilities/required-targets [[:row-affinity "" 1]])))
 
 (defexpect strengthen-and-weaken
 
   ; Adds power
   (expect
     7
-    (get-in ((abilities/generate-ability-fn [:strengthen 5]) {:cards [{:power 2}]} {:target 0})
+    (get-in ((abilities/generate-ability-fn [[:strengthen 5]]) {:cards [{:power 2}]} {:target 0})
             [:cards 0 :power]))
 
   ; Removes power
   (expect
     -10
-    (get-in ((abilities/generate-ability-fn [:weaken 13]) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
+    (get-in ((abilities/generate-ability-fn [[:weaken 13]]) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 
 (defexpect row-affinity
@@ -32,20 +32,20 @@
   ; Does nothing when shouldn't
   (expect
     42
-    (get-in ((abilities/generate-ability-fn [:row-affinity "invi" 10]) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
+    (get-in ((abilities/generate-ability-fn [[:row-affinity "invi" 10]]) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
             [:cards 0 :power]))
   (expect
     99
-    (get-in ((abilities/generate-ability-fn [:row-affinity "invi" 10]) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
+    (get-in ((abilities/generate-ability-fn [[:row-affinity "invi" 10]]) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
             [:cards 1 :power]))
   
   ; Adds power when should
   (expect
     52
-    (get-in ((abilities/generate-ability-fn [:row-affinity "invi" 10]) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
+    (get-in ((abilities/generate-ability-fn [[:row-affinity "invi" 10]]) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
             [:cards 0 :power]))
 
   (expect
     -2
-    (get-in ((abilities/generate-ability-fn [:row-affinity "vivi" -3]) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
+    (get-in ((abilities/generate-ability-fn [[:row-affinity "vivi" -3]]) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
             [:cards 1 :power])))

--- a/test/rules/abilities_test.clj
+++ b/test/rules/abilities_test.clj
@@ -21,13 +21,13 @@
   ; Adds power
   (expect
     7
-    (get-in ((abilities/generate-abilities-fn [[:strengthen 5]]) {:cards [{:power 2}]} {:target 0})
+    (get-in ((abilities/generate-abilities-fn [[:strengthen 5]]) {:cards [{:power 2}]} {:targets [0]})
             [:cards 0 :power]))
 
   ; Removes power
   (expect
     -10
-    (get-in ((abilities/generate-abilities-fn [[:weaken 13]]) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
+    (get-in ((abilities/generate-abilities-fn [[:weaken 13]]) {:cards [{}{:power 3}]} {:targets [1] :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 
 (defexpect row-affinity
@@ -71,7 +71,7 @@
   
   (expect
     100
-    (get-in ((abilities/generate-abilities-fn [[:row-affinity "somewhere" 1000][:strengthen 1]]) {:cards [{:power 99}]} {:target 0})
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "somewhere" 1000][:strengthen 1]]) {:cards [{:power 99}]} {:targets [0]})
             [:cards 0 :power]))
 
   (expect

--- a/test/rules/abilities_test.clj
+++ b/test/rules/abilities_test.clj
@@ -67,4 +67,13 @@
     (get-in ((abilities/generate-abilities-fn [[:row-affinity "first-row" 10][:row-affinity "second-row" 100]])
              {:cards [{:power 1}] :rows [{:type "first-row"} {:type "second-row"}]}
              {:row-id 1 :card-id 0})
-            [:cards 0 :power])))
+            [:cards 0 :power]))
+  
+  (expect
+    100
+    (get-in ((abilities/generate-abilities-fn [[:row-affinity "somewhere" 1000][:strengthen 1]]) {:cards [{:power 99}]} {:target 0})
+            [:cards 0 :power]))
+
+  (expect
+    [{:power 101}{:power -98}]
+    (:cards ((abilities/generate-abilities-fn [[:strengthen 100][:weaken 100]]) {:cards [{:power 1}{:power 2}]} {:targets [0 1]}))))

--- a/test/rules/play_card_test.clj
+++ b/test/rules/play_card_test.clj
@@ -4,8 +4,8 @@
             [configs.messages :as messages]))
 
   (def game-state {:cards [{:power 0 :location [:hand]}
-                           {:power 10 :abilities [:strengthen 1]}
-                           {:power 100 :abilities [:weaken 100]}]
+                           {:power 10 :abilities [[:strengthen 1]]}
+                           {:power 100 :abilities [[:weaken 100]]}]
                    :rows [{}{}{}{}]
                    :next-play {:p0 {:card-id 0 :row-id 0} :p1 {:card-id 1 :row-id 3 :target 2}}
                    :player-ids ["p0" "p1"]})
@@ -86,13 +86,13 @@
     {:error messages/need-target}
     (play-card/play-card {:next-play {}
                           :rows [{}]
-                          :cards [{:abilities [:strengthen 9000] :owner "dumb"}]} "dumb" 0 0))
+                          :cards [{:abilities [[:strengthen 9000]] :owner "dumb"}]} "dumb" 0 0))
 
   (expect
     {:error messages/invalid-target}
     (play-card/play-card {:next-play {}
                           :rows [{}]
-                          :cards [{:abilities [:weaken 1] :owner "McCheaty"}{:location ["nowhere"]}]} "McCheaty" 0 0 1))
+                          :cards [{:abilities [[:weaken 1]] :owner "McCheaty"}{:location ["nowhere"]}]} "McCheaty" 0 0 1))
   
   ; Saves next-play
   (expect
@@ -120,8 +120,8 @@
   (let [new-game-state
         (play-card/play-card 
           {:cards [{:power 0 :location [:hand] :owner "p0"}
-                   {:power 10 :owner "p1" :abilities [:strengthen 1]}
-                   {:power 100 :abilities [:weaken 100]}]
+                   {:power 10 :owner "p1" :abilities [[:strengthen 1]]}
+                   {:power 100 :abilities [[:weaken 100]]}]
            :rows [{}{}{}{}{}]
            :next-play {:p1 {:card-id 1 :row-id 3 :target 2}}}
           "p0" 0 0)]

--- a/test/rules/play_card_test.clj
+++ b/test/rules/play_card_test.clj
@@ -33,12 +33,12 @@
   ; Changes power
   (expect
     101
-    (get-in (play-card/apply-ability game-state {:card-id 1 :target 2})
+    (get-in (play-card/apply-ability game-state {:card-id 1 :targets [2]})
             [:cards 2 :power]))
   
   (expect
     -100
-    (get-in (play-card/apply-ability game-state {:card-id 2 :target 0})
+    (get-in (play-card/apply-ability game-state {:card-id 2 :targets [0]})
             [:cards 0 :power])))
 
 (defexpect crowded-row?
@@ -96,18 +96,18 @@
   
   ; Saves next-play
   (expect
-    {:saver {:card-id 0 :row-id 1 :target nil}}
+    {:saver {:card-id 0 :row-id 1 :targets nil}}
     (:next-play
       (play-card/play-card {:next-play {} 
                             :rows [{}{}{}]
                             :cards [{:owner "saver"}]} "saver" 0 1)))
   
   (expect
-    {:p {:card-id 2 :row-id 3 :target 0}}
+    {:p {:card-id 2 :row-id 3 :targets [0]}}
     (:next-play
       (play-card/play-card {:next-play {}
                             :rows [{}{}{}{}]
-                            :cards [{:location [:row 0]}{}{:owner "p" :target 1}]} "p" 2 3 0)))
+                            :cards [{:location [:row 0]}{}{:owner "p" :target 1}]} "p" 2 3 [0])))
 
   (expect
     [{:owner "p"}]
@@ -123,7 +123,7 @@
                    {:power 10 :owner "p1" :abilities [[:strengthen 1]]}
                    {:power 100 :abilities [[:weaken 100]]}]
            :rows [{}{}{}{}{}]
-           :next-play {:p1 {:card-id 1 :row-id 3 :target 2}}}
+           :next-play {:p1 {:card-id 1 :row-id 3 :targets [2]}}}
           "p0" 0 0)]
     (expect
       [:row 0]


### PR DESCRIPTION
**Description**

Now cards can have multiple abilities. Each ability that uses a target will require a different target.

**Issues Resolved**

Resolves #26 

**Details**

- `:abilities` is a vector of abilities, where each ability is another vector.
- `:play` now have `:targets` a vector of one or more targets.
- Internally abilities use `gsp` which is `{:game-state game-state :play play}`. Publicly they are called as before, where both game-state and play are two different arguments.
- Through `(comp` all the abilities are collapsed into a one single function.

**Hotspots**

Maybe it'll be worth making sure we always have `:targets`, even when none is needed.
It's possible that some other test would be interesting. Also, I'd be happy to remove redundant tests, since those require manual when some things are changed.

**Checklist for contribution requirements**

- [x] The tests pass
- [x] The code has tests
- [x] The tests are well-designed
- [x] The code is readable
- [x] The code is well-organized
- [x] Any rule changed or included is also on the Manual
